### PR TITLE
fix etcd alert rule: InsufficientMembers

### DIFF
--- a/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-rules.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus/prometheus-k8s-rules.yaml
@@ -45,7 +45,7 @@ data:
     - name: ./etcd3.rules
       rules:
       - alert: InsufficientMembers
-        expr: count(up{job="etcd"} == 0) > (count(up{job="etcd"}) / 2 - 1)
+        expr: count(up{job="etcd"} == 0) > ((count(up{job="etcd"}) - 1) / 2)
         for: 3m
         labels:
           severity: critical


### PR DESCRIPTION
(count(up{job="etcd"}) / 2 - 1) 
if count = 3, then (count(up{job="etcd"}) / 2 - 1)  = 0.5
This will also trigger an alarm if only one etcd is down.
So the rules should be written like this:
((count(up{job="etcd"}) - 1) / 2)